### PR TITLE
Events are assigned time zones automatically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'icalendar'
 gem 'pg' if ENV['FORCE_POSTGRES']
 gem 'rack-mini-profiler'
 gem 'bower-rails'
+gem 'timezone'
 
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timezone (1.2.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
@@ -396,6 +397,7 @@ DEPENDENCIES
   simple_form
   sqlite3
   test_after_commit
+  timezone
   uglifier
   webmock
 

--- a/README.markdown
+++ b/README.markdown
@@ -139,6 +139,8 @@ MEETUP_OAUTH_SECRET=5551212
 RAILS_ENV=development
 RACK_ENV=development
 PORT=3000
+GOOGLE_TIMEZONE_API_KEY=ABC123
+GOOGLE_FOR_WORK_CLIENT_ID=8888 (optional)
 ```
 
 With the `.env` file in place, the environment variables will be set every time you start the server with `rails s`.

--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -69,3 +69,8 @@ jQuery ->
     $dateField = $field.find('.datepicker')
     setUpDatePicker($dateField)
     setUpExclusiveCheckboxes($field)
+
+  $event_location = $('#event_location_id')
+  $event_location.on 'change', (event) ->
+    $.get "/locations/#{$event_location.val()}/timezone", (data) ->
+      $('#event_time_zone').val(data['name'])

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,6 +1,6 @@
 class LocationsController < ApplicationController
-  before_action :authenticate_user!, except: [:show, :index]
-  before_action :assign_location, only: [:show, :edit, :update, :destroy, :archive]
+  before_action :authenticate_user!, except: [:show, :index, :timezone]
+  before_action :assign_location, only: [:show, :edit, :update, :destroy, :archive, :timezone]
 
   def index
     skip_authorization
@@ -9,6 +9,13 @@ class LocationsController < ApplicationController
 
   def show
     skip_authorization
+  end
+
+  def timezone
+    skip_authorization
+    respond_to do |format|
+      format.json { render json: @location.get_timezone }
+    end
   end
 
   def new

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -12,6 +12,13 @@ class Location < ActiveRecord::Base
     after_validation :geocode
   end
 
+  def get_timezone
+    timezone_lookup = Timezone.lookup(latitude, longitude)
+    ActiveSupport::TimeZone.all.detect do |timezone|
+      timezone.tzinfo.identifier == timezone_lookup.name
+    end
+  end
+
   def full_address
     "#{address_1}, #{city}, #{state}, #{zip}"
   end

--- a/config/initializers/timezone_gem.rb
+++ b/config/initializers/timezone_gem.rb
@@ -1,0 +1,6 @@
+if ENV['GOOGLE_TIMEZONE_API_KEY']
+  Timezone::Lookup.config(:google) do |c|
+    c.api_key = ENV['GOOGLE_TIMEZONE_API_KEY']
+    c.client_id = ENV['GOOGLE_FOR_WORK_CLIENT_ID'] if ENV['GOOGLE_FOR_WORK_CLIENT_ID']
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Bridgetroll::Application.routes.draw do
 
   resources :locations do
     patch :archive, on: :member
+    get :timezone, on: :member
   end
 
   resources :chapters do

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -111,5 +111,23 @@ describe LocationsController do
         }.not_to change(Location, :count)
       end
     end
+
+    describe '#timezone (json)' do
+      subject { get :timezone, format: 'json', id: @location.id }
+
+      before do
+        @location.update(
+          latitude: 37.0,
+          longitude: -122.0
+        )
+        ::Timezone::Lookup.lookup.stub(37.0, -122.0, 'America/Los_Angeles')
+      end
+
+      it "returns the location's timezone information as JSON" do
+        expect(JSON.parse(subject.body)["name"]).to eq(
+          "Pacific Time (US & Canada)"
+        )
+      end
+    end
   end
 end

--- a/spec/features/new_event_request_spec.rb
+++ b/spec/features/new_event_request_spec.rb
@@ -77,6 +77,21 @@ describe "New Event" do
     ])
   end
 
+  it "sets the timezone when the location changes", js: true do
+    live_location = create(
+      :location,
+      latitude: 37.0,
+      longitude: -122.0
+      )
+      ::Timezone::Lookup.lookup.stub(37.0, -122.0, 'America/Denver')
+
+    visit "/events/new"
+    expect(page).to have_select('event_time_zone', selected: 'Select Time Zone')
+    page.execute_script("$('#event_location_id').val(#{live_location.id})")
+    page.execute_script("$('#event_location_id').trigger('change')")
+    expect(page).to have_select('event_time_zone', selected: '(GMT-07:00) Mountain Time (US & Canada)')
+  end
+
   it 'allows organizers to specify a whitelist of allowed OSes', js: true do
     fill_in_good_event_details
 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -68,4 +68,23 @@ describe Location do
       end
     end
   end
+
+  describe "#get_timezone" do
+    subject { location.get_timezone }
+    let(:location) do
+      described_class.new(
+        latitude: 37.0,
+        longitude: -122.0
+      )
+    end
+
+    before do
+      ::Timezone::Lookup.lookup.stub(37.0, -122.0, 'America/Los_Angeles')
+    end
+
+    it "returns the correct ActiveSupport::TimeZone object" do
+      expect(subject.class).to eq(ActiveSupport::TimeZone)
+      expect(subject.name).to eq("Pacific Time (US & Canada)")
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,7 @@ RSpec.configure do |config|
     WebMock.disable_net_connect!(allow_localhost: true)
     Time.zone = 'UTC'
     ActionMailer::Base.deliveries.clear
+    Timezone::Lookup.config(:test)
   end
 
   config.include Devise::TestHelpers, type: :controller


### PR DESCRIPTION
This PR implements:
- `Location#get_timezone` which uses the Google Time Zone API to lookup the correct time zone for a location.
- A JavaScript event listener to update the time zone drop down when creating a new event based on the users selected location.

See https://github.com/railsbridge/bridge_troll/issues/390 for full details about the exercise.